### PR TITLE
Result and graph sections are now sticky and scroll to top when changing category

### DIFF
--- a/src/Effect.elm
+++ b/src/Effect.elm
@@ -20,6 +20,11 @@ port setSituation : Json.Encode.Value -> Cmd msg
 port updateSituation : ( P.RuleName, Json.Encode.Value ) -> Cmd msg
 
 
+{-| window.scrollTo
+-}
+port scrollTo : ( Int, Int ) -> Cmd msg
+
+
 
 -- SUBSCRIPTIONS
 

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -300,8 +300,10 @@ view model =
 
                           else
                             div [ class "flex flex-col p-4 lg:pl-4 lg:col-span-1 lg:pr-8" ]
-                                [ lazy viewResults model
-                                , lazy viewGraph model
+                                [ div [ class "lg:sticky lg:top-4" ]
+                                    [ lazy viewResults model
+                                    , lazy viewGraph model
+                                    ]
                                 ]
                         ]
                     ]

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -211,7 +211,11 @@ update msg model =
             evaluate model
 
         ChangeTab category ->
-            evaluate { model | currentTab = Just category }
+            let
+                ( newModel, cmd ) =
+                    evaluate { model | currentTab = Just category }
+            in
+            ( newModel, Cmd.batch [ Effect.scrollTo ( 0, 0 ), cmd ] )
 
         SetSubCategoryGraphStatus category status ->
             let

--- a/src/main.ts
+++ b/src/main.ts
@@ -21,6 +21,10 @@ const engine = await EkofestEngine.createAsync(rules, situation, app)
 
 app.ports.engineInitialized.send(null)
 
+app.ports.scrollTo.subscribe((x: number, y: number) => {
+    window.scrollTo(x, y)
+})
+
 app.ports.setSituation.subscribe((newSituation: Situation) => {
     engine.setSituation(newSituation)
     localStorage.setItem("situation", JSON.stringify(newSituation))


### PR DESCRIPTION
Closes #22 and #13 

> [!NOTE]
> For now, the result section is only sticky if in flex-row (breakpoint lg).